### PR TITLE
MMDC compliance, subgraph support and sanitization of input

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Returns the following
 ---
 title: Little Women
 ---
-graph 
+graph TD
 meg["Meg"]
 jo["Jo"]
 beth["Beth"]

--- a/examples/daily_activity.py
+++ b/examples/daily_activity.py
@@ -11,27 +11,22 @@ work_again = StateNode("Work again")
 visit_parents = StateNode("Visit parents")
 dinner = StateNode("Eat dinner")
 
-m = MermaidDiagram(type="statechart",
-                   nodes = [sleep, 
-                            breakfast, 
-                            work, 
-                            fun, 
-                            lunch, 
-                            work_again, 
-                            visit_parents, 
-                            dinner],
-                   links =  [
-                       StateLink(sleep, breakfast),
-                       StateLink(breakfast, work, "Working day"),
-                       StateLink(work, lunch, "Have time for lunch"),
-                       StateLink(work, work_again, "No time for lunch"),
-                       StateLink(work_again, dinner),
-                       StateLink(dinner, sleep),
-                       StateLink(breakfast, fun, "Weekend"),
-                       StateLink(fun, lunch),
-                       StateLink(lunch, visit_parents),
-                       StateLink(visit_parents, dinner)
-                   ])
+m = MermaidDiagram(
+    type="statechart",
+    nodes=[sleep, breakfast, work, fun, lunch, work_again, visit_parents, dinner],
+    links=[
+        StateLink(sleep, breakfast),
+        StateLink(breakfast, work, "Working day"),
+        StateLink(work, lunch, "Have time for lunch"),
+        StateLink(work, work_again, "No time for lunch"),
+        StateLink(work_again, dinner),
+        StateLink(dinner, sleep),
+        StateLink(breakfast, fun, "Weekend"),
+        StateLink(fun, lunch),
+        StateLink(lunch, visit_parents),
+        StateLink(visit_parents, dinner),
+    ],
+)
 
 m.add_start_and_end_nodes(breakfast, None)
 print(m)

--- a/examples/framasoft.py
+++ b/examples/framasoft.py
@@ -1,38 +1,16 @@
 # Using a wonderful french association to demonstrate interactions and subgraph
-from python_mermaid.diagram import (
-    MermaidDiagram,
-    Node,
-    Interaction
-)
+from python_mermaid.diagram import MermaidDiagram, Node, Interaction
 
 
 framatools = {
-    "practical_tools": [
-        "Framaforms",
-        "Framindmap",
-        "Framacart"
-    ],
-    "exchange_tools": [
-        "Framatalk",
-        "Framalistes",
-        "Framateam"
-    ],
+    "practical_tools": ["Framaforms", "Framindmap", "Framacart"],
+    "exchange_tools": ["Framatalk", "Framalistes", "Framateam"],
     "entertainment_tools": [
         ("Framinetest Édu", "https://framinetest.org"),
     ],
-    "organizing_tools": [
-        "Framadate",
-        "Framagenda",
-        "Framavox",
-        "Mobilizon"
-    ],
-    "collaborating_tools": [
-        "Framacalc",
-        "Framapad"
-    ],
-    "developing_tools": [
-        "Framagit"
-    ]
+    "organizing_tools": ["Framadate", "Framagenda", "Framavox", "Mobilizon"],
+    "collaborating_tools": ["Framacalc", "Framapad"],
+    "developing_tools": ["Framagit"],
 }
 
 nodes = []
@@ -46,18 +24,11 @@ for group, tools in framatools.items():
         else:
             node_tool = Node(tool)
             interactions.append(
-                Interaction(
-                    node_tool,
-                    args=[f"\"https://{node_tool.id}.org\""]
-                )
+                Interaction(node_tool, args=[f'"https://{node_tool.id}.org"'])
             )
         node_group.add_sub_nodes([node_tool])
     nodes += [node_group]
 
-m = MermaidDiagram(
-    title="Framaverse",
-    nodes=nodes,
-    interactions=interactions
-)
+m = MermaidDiagram(title="Framaverse", nodes=nodes, interactions=interactions)
 
 print(m)

--- a/examples/the_march_family.py
+++ b/examples/the_march_family.py
@@ -1,9 +1,5 @@
 # Creating a simple flowchart diagram, without any interactions nor style
-from python_mermaid.diagram import (
-    MermaidDiagram,
-    Node,
-    Link
-)
+from python_mermaid.diagram import MermaidDiagram, Node, Link
 
 # Family members
 meg = Node("Meg")
@@ -22,10 +18,6 @@ family_links = [
     Link(robert, amy),
 ]
 
-chart = MermaidDiagram(
-    title="Little Women",
-    nodes=the_march_family,
-    links=family_links
-)
+chart = MermaidDiagram(title="Little Women", nodes=the_march_family, links=family_links)
 
 print(chart)

--- a/python_mermaid/diagram.py
+++ b/python_mermaid/diagram.py
@@ -6,7 +6,7 @@ from .interaction import Interaction
 DIAGRAM_TYPES = {
     "default": "graph",
     "flowchart": "flowchart",
-    "statechart": "stateDiagram-v2"
+    "statechart": "stateDiagram-v2",
 }
 
 DIAGRAM_ORIENTATION = {
@@ -27,7 +27,7 @@ class MermaidDiagram:
         links: List[Link] = [],
         interactions: List[Interaction] = [],
         type="default",
-        orientation="default"
+        orientation="default",
     ):
         self.title = title
         self.nodes = nodes
@@ -44,21 +44,19 @@ class MermaidDiagram:
     def add_links(self, links=[]):
         self.links += links
 
-    def add_start_and_end_nodes(self, 
-                                start_node:Optional[AbstractNode] = None, 
-                                end_node:Optional[AbstractNode] = None):
-        self.startNode = start_node # type: ignore
-        self.endNode = end_node # type: ignore
+    def add_start_and_end_nodes(
+        self,
+        start_node: Optional[AbstractNode] = None,
+        end_node: Optional[AbstractNode] = None,
+    ):
+        self.startNode = start_node  # type: ignore
+        self.endNode = end_node  # type: ignore
 
     def __get_graph_str(self):
-        nodes_string = (
-            '\n'.join([str(node) for node in self.nodes])
-        )
-        links_string = (
-            '\n'.join([str(link) for link in self.links])
-        )
-        interactions_string = (
-            '\n'.join([str(interaction) for interaction in self.interactions])
+        nodes_string = "\n".join([str(node) for node in self.nodes])
+        links_string = "\n".join([str(link) for link in self.links])
+        interactions_string = "\n".join(
+            [str(interaction) for interaction in self.interactions]
         )
         final_strings = list(
             filter(
@@ -67,19 +65,15 @@ class MermaidDiagram:
                     f"{self.type} {self.orientation}",
                     nodes_string,
                     links_string,
-                    interactions_string
-                ]
+                    interactions_string,
+                ],
             )
         )
-        return '\n'.join(final_strings)
-    
+        return "\n".join(final_strings)
+
     def __get_state_diagram_str(self):
-        nodes_string = (
-            '\n'.join([str(node) for node in self.nodes if str(node)!=""])
-        )
-        links_string = (
-            '\n'.join([str(link) for link in self.links])
-        )
+        nodes_string = "\n".join([str(node) for node in self.nodes if str(node) != ""])
+        links_string = "\n".join([str(link) for link in self.links])
         final_strings = list(
             filter(
                 None,
@@ -88,11 +82,11 @@ class MermaidDiagram:
                     nodes_string,
                     f"[*] --> {self.startNode.id}" if self.startNode else None,
                     links_string,
-                    f"{self.endNode.id} --> [*]" if self.endNode else None
-                ]
+                    f"{self.endNode.id} --> [*]" if self.endNode else None,
+                ],
             )
         )
-        return '\n'.join(final_strings)
+        return "\n".join(final_strings)
 
     def __str__(self):
         self.string = f"---\ntitle: {self.title}\n---\n" if self.title else ""
@@ -103,4 +97,3 @@ class MermaidDiagram:
             content = self.__get_state_diagram_str()
         self.string += content
         return self.string
-        

--- a/python_mermaid/diagram.py
+++ b/python_mermaid/diagram.py
@@ -22,20 +22,64 @@ class MermaidDiagram:
     def __init__(
         self,
         title: str = "",
-        nodes: List[Node] = [],
-        links: List[Link] = [],
-        interactions: List[Interaction] = [],
+        nodes: Optional[List[Node]] = None,
+        links: Optional[List[Link]] = None,
+        interactions: Optional[List[Interaction]] = None,
         type="default",
         orientation="top-down",
     ):
         self.title = title
-        self.nodes = nodes
-        self.links = links
-        self.interactions = interactions
         self.type = DIAGRAM_TYPES[type]
         self.orientation = DIAGRAM_ORIENTATION[orientation]
+        self.graph = Graph(
+            header=f"{self.type} {self.orientation}",
+            nodes=nodes,
+            links=links,
+            interactions=interactions,
+        )
+
+    def add_nodes(self, nodes=[]):
+        self.graph.add_nodes(nodes)
+
+    def add_links(self, links=[]):
+        self.graph.add_links(links)
+
+    def add_start_and_end_nodes(
+        self,
+        start_node: Optional[AbstractNode] = None,
+        end_node: Optional[AbstractNode] = None,
+    ):
+        self.graph.add_start_and_end_nodes(start_node, end_node)
+
+    def add_subgraph(self, name: str) -> "Graph":
+        return self.graph.add_subgraph(name)
+
+    def __str__(self) -> str:
+        s = f"---\ntitle: {self.title}\n---\n" if self.title else ""
+        content = ""
+        if self.type == "graph":
+            content = self.graph.get_graph_str()
+        elif self.type == "stateDiagram-v2":
+            content = self.graph.get_state_diagram_str()
+        s += content
+        return s
+
+
+class Graph:
+    def __init__(
+        self,
+        header: str,
+        nodes: Optional[List[Node]] = None,
+        links: Optional[List[Link]] = None,
+        interactions: Optional[List[Interaction]] = None,
+    ):
+        self.header = header
+        self.nodes = nodes if type(nodes) is list else []
+        self.links = links if type(links) is list else []
+        self.interactions = interactions if type(interactions) is list else []
         self.startNode = None
         self.endNode = None
+        self.sub_graphs = []
 
     def add_nodes(self, nodes=[]):
         self.nodes += nodes
@@ -51,48 +95,49 @@ class MermaidDiagram:
         self.startNode = start_node  # type: ignore
         self.endNode = end_node  # type: ignore
 
-    def __get_graph_str(self):
+    def add_subgraph(self, name: str) -> "Graph":
+        s = Graph(f"subgraph {name}")
+        self.sub_graphs.append(s)
+        return s
+
+    def get_graph_str(self):
         nodes_string = "\n".join([str(node) for node in self.nodes])
         links_string = "\n".join([str(link) for link in self.links])
         interactions_string = "\n".join(
             [str(interaction) for interaction in self.interactions]
         )
+        sub_graphs = "\n".join([f"{g.get_graph_str()}\nend" for g in self.sub_graphs])
         final_strings = list(
             filter(
                 None,
                 [
-                    f"{self.type} {self.orientation}",
+                    self.header,
                     nodes_string,
                     links_string,
                     interactions_string,
+                    sub_graphs,
                 ],
             )
         )
         return "\n".join(final_strings)
 
-    def __get_state_diagram_str(self):
+    def get_state_diagram_str(self):
         nodes_string = "\n".join([str(node) for node in self.nodes if str(node) != ""])
         links_string = "\n".join([str(link) for link in self.links])
+        sub_graphs = "\n".join(
+            [f"{g.get_state_diagram_str()}\nend" for g in self.sub_graphs]
+        )
         final_strings = list(
             filter(
                 None,
                 [
-                    f"{self.type}",
+                    f"{self.header}",
                     nodes_string,
                     f"[*] --> {self.startNode.id}" if self.startNode else None,
                     links_string,
                     f"{self.endNode.id} --> [*]" if self.endNode else None,
+                    sub_graphs,
                 ],
             )
         )
         return "\n".join(final_strings)
-
-    def __str__(self):
-        self.string = f"---\ntitle: {self.title}\n---\n" if self.title else ""
-        content = ""
-        if self.type == "graph":
-            content = self.__get_graph_str()
-        elif self.type == "stateDiagram-v2":
-            content = self.__get_state_diagram_str()
-        self.string += content
-        return self.string

--- a/python_mermaid/diagram.py
+++ b/python_mermaid/diagram.py
@@ -10,7 +10,6 @@ DIAGRAM_TYPES = {
 }
 
 DIAGRAM_ORIENTATION = {
-    "default": "",
     "top to bottom": "TB",
     "top-down": "TD",
     "bottom to top": "BT",
@@ -27,7 +26,7 @@ class MermaidDiagram:
         links: List[Link] = [],
         interactions: List[Interaction] = [],
         type="default",
-        orientation="default",
+        orientation="top-down",
     ):
         self.title = title
         self.nodes = nodes

--- a/python_mermaid/interaction.py
+++ b/python_mermaid/interaction.py
@@ -3,10 +3,7 @@ from .node import Node
 
 # List of all interactions are documented here
 # https://mermaid.js.org/syntax/flowchart.html#interaction
-INTERACTION_TYPE = {
-    "link": "href",
-    "callback": "call callback()"
-}
+INTERACTION_TYPE = {"link": "href", "callback": "call callback()"}
 
 
 class Interaction:

--- a/python_mermaid/link.py
+++ b/python_mermaid/link.py
@@ -1,4 +1,5 @@
 from .node import AbstractNode, StateNode
+from .utils import sanitize_string
 
 # Link are created following the documentation here :
 # https://mermaid.js.org/syntax/flowchart.html#links-between-nodes
@@ -22,7 +23,7 @@ class Link:
         self.head_left = LINK_HEADS[head_left]
         self.head_right = LINK_HEADS[head_right]
         self.shape = LINK_SHAPES[shape]
-        self.message = message
+        self.message = sanitize_string(message)
 
     def __str__(self):
         elements = [

--- a/python_mermaid/link.py
+++ b/python_mermaid/link.py
@@ -2,19 +2,9 @@ from .node import AbstractNode, StateNode
 
 # Link are created following the documentation here :
 # https://mermaid.js.org/syntax/flowchart.html#links-between-nodes
-LINK_SHAPES = {
-    "normal": "---",
-    "dotted": "-.-",
-    "thick": "==="
-}
+LINK_SHAPES = {"normal": "---", "dotted": "-.-", "thick": "==="}
 
-LINK_HEADS = {
-    "none": "",
-    "arrow": ">",
-    "left-arrow": "<",
-    "bullet": "o",
-    "cross": "x"
-}
+LINK_HEADS = {"none": "", "arrow": ">", "left-arrow": "<", "bullet": "o", "cross": "x"}
 
 
 class Link:
@@ -25,7 +15,7 @@ class Link:
         shape: str = "normal",
         head_left: str = "none",
         head_right: str = "arrow",
-        message: str = ""
+        message: str = "",
     ):
         self.origin = origin
         self.end = end
@@ -41,10 +31,11 @@ class Link:
             self.shape,
             self.head_right,
             f"|{self.message}|" if self.message else "",
-            " " + self.end.id
+            " " + self.end.id,
         ]
         return "".join(elements)
-    
+
+
 class StateLink(Link):
     def __init__(self, origin: StateNode, end: StateNode, message: str = ""):
         super().__init__(origin, end, "normal", "none", "arrow", message)

--- a/python_mermaid/node.py
+++ b/python_mermaid/node.py
@@ -7,6 +7,7 @@ class NodeShape:
         self.start = start
         self.end = end
 
+
 # Shapes are created following the documentation here :
 # https://mermaid.js.org/syntax/flowchart.html#node-shapes
 
@@ -28,17 +29,15 @@ NODE_SHAPES = {
     "double-circle": NodeShape("(((", ")))"),
 }
 
+
 class AbstractNode:
-    def __init__(
-            self,
-            id: str,
-            content: str = ""
-    ):
+    def __init__(self, id: str, content: str = ""):
         self.id = snake_case(id)
         self.content = content if content else id
-    
+
     def __repr__(self):
         return f"{self.id}['{self.content}']"
+
 
 class Node(AbstractNode):
     def __init__(
@@ -54,7 +53,7 @@ class Node(AbstractNode):
 
         # TODO: verify that content match a working string pattern
 
-    def add_sub_nodes(self, new_nodes: List['Node'] = []):
+    def add_sub_nodes(self, new_nodes: List["Node"] = []):
         self.sub_nodes = self.sub_nodes + new_nodes
 
     def __repr__(self):
@@ -63,47 +62,44 @@ class Node(AbstractNode):
     def __str__(self):
         s = ""
         if len(self.sub_nodes):
-            s += '\n'.join([
-                f'subgraph {self.id} ["{self.content}"]',
-                '\n'.join([str(node) for node in self.sub_nodes]),
-                "end"
-            ])
+            s += "\n".join(
+                [
+                    f'subgraph {self.id} ["{self.content}"]',
+                    "\n".join([str(node) for node in self.sub_nodes]),
+                    "end",
+                ]
+            )
         else:
-            s += ''.join([
-                self.id,
-                self.shape.start,
-                '"' + self.content + '"',
-                self.shape.end
-            ])
+            s += "".join(
+                [self.id, self.shape.start, '"' + self.content + '"', self.shape.end]
+            )
         return s
 
+
 class StateNode(AbstractNode):
-    def __init__(
-            self,
-            id: str,
-            content: str = ""
-    ):
+    def __init__(self, id: str, content: str = ""):
         self.id = snake_case(id)
         self.content = id if content == "" else content
         self.note = None
 
     def add_note(self, message, position="right"):
-        self.note = {
-            "message": message,
-            "position": position
-        }
+        self.note = {"message": message, "position": position}
 
     def __str__(self):
         if self.content == self.id:
             result = ""
         else:
-            result = f"state \"{self.content}\" as {self.id}"
+            result = f'state "{self.content}" as {self.id}'
         if self.note:
-            if "\n" in self.note['message']:
-                result += f"\nnote {self.note['position']} of {self.id}" \
-                + f"\n{self.note['message']}" \
-                + "\nend note"
+            if "\n" in self.note["message"]:
+                result += (
+                    f"\nnote {self.note['position']} of {self.id}"
+                    + f"\n{self.note['message']}"
+                    + "\nend note"
+                )
             else:
-                result += f"\nnote {self.note['position']} of {self.id}: " \
-                       +  f"{self.note['message']}"
+                result += (
+                    f"\nnote {self.note['position']} of {self.id}: "
+                    + f"{self.note['message']}"
+                )
         return result

--- a/python_mermaid/node.py
+++ b/python_mermaid/node.py
@@ -1,5 +1,5 @@
 from typing import List
-from .utils import snake_case
+from .utils import snake_case, sanitize_string
 
 
 class NodeShape:
@@ -34,6 +34,7 @@ class AbstractNode:
     def __init__(self, id: str, content: str = ""):
         self.id = snake_case(id)
         self.content = content if content else id
+        self.content = sanitize_string(self.content)
 
     def __repr__(self):
         return f"{self.id}['{self.content}']"

--- a/python_mermaid/utils.py
+++ b/python_mermaid/utils.py
@@ -11,3 +11,14 @@ def snake_case(s):
     ).lower()
 
     return s
+
+
+def sanitize_string(s: str) -> str:
+    # fmt: off
+    translation_table = str.maketrans({
+        "\n": "/",
+        "\t": "/",
+        "\r": ""
+    })
+    # fmt: on
+    return s.translate(translation_table)

--- a/python_mermaid/utils.py
+++ b/python_mermaid/utils.py
@@ -4,10 +4,9 @@ from unidecode import unidecode
 
 def snake_case(s):
     s = unidecode(s)
-    s = '_'.join(
+    s = "_".join(
         sub(
-            '([A-Z][a-z]+)', r' \1',
-            sub('([A-Z]+)', r' \1', s.replace('-', ' '))
+            "([A-Z][a-z]+)", r" \1", sub("([A-Z]+)", r" \1", s.replace("-", " "))
         ).split()
     ).lower()
 

--- a/python_mermaid/utils.py
+++ b/python_mermaid/utils.py
@@ -18,7 +18,9 @@ def sanitize_string(s: str) -> str:
     translation_table = str.maketrans({
         "\n": "/",
         "\t": "/",
-        "\r": ""
+        "\r": "",
+        "(": "-",
+        ")": "-"
     })
     # fmt: on
     return s.translate(translation_table)


### PR DESCRIPTION
The commits implement:

- black on all sources
- mmdc compliance, e.g. defaulting to TD as graph instead of leaving it empty
- sanitizing / replacing some input strings, which may break the diagram (e.g. \t, \n, \r)
- Subgraph support